### PR TITLE
Use Halley for realtime communications instead of Faye

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swo
 node_modules
 npm-debug.log
+.env

--- a/lib/faye.js
+++ b/lib/faye.js
@@ -1,7 +1,9 @@
 /* jshint node:true, unused:true */
+'use strict';
 
-var Faye = require('gitter-faye');
+var Halley = require('halley');
 var EventEmitter = require('eventemitter3');
+var Promise = require('bluebird');
 
 // Authentication extension for Faye
 var ClientAuthExt = function(opts) {
@@ -41,7 +43,7 @@ var FayeClient = function(token, opts) {
 
   this.subscriptions = {};
 
-  this.client = new Faye.Client(host, {timeout: 60, retry: 5, interval: 1});
+  this.client = new Halley.Client(host);
   this.client.addExtension(new ClientAuthExt({token: token, clientType: opts.clientType}));
   this.client.addExtension(new SnapshotExt({subscriptions: this.subscriptions}));
 };
@@ -50,14 +52,14 @@ FayeClient.prototype.subscribeTo = function(resource, eventName) {
   if (this.subscriptions[resource]) return this.subscriptions[resource].emitter;
 
   var emitter = new EventEmitter();
-  var subscription = this.client.subscribe(resource, function(msg) {
+  var subscribe = this.client.subscribe(resource, function(msg) {
     emitter.emit(eventName, msg);
-  });
+  }); // TODO: catch
 
   this.subscriptions[resource] = {
     eventName:      eventName,
     emitter:        emitter,
-    subscription:   subscription
+    subscribe:      subscribe
   };
 
   return emitter;
@@ -66,10 +68,33 @@ FayeClient.prototype.subscribeTo = function(resource, eventName) {
 FayeClient.prototype.disconnect = function() {
   var self = this;
 
-  Object.keys(this.subscriptions).forEach(function(sub) {
-    self.subscriptions[sub].subscription.cancel();
-    self.subscriptions[sub].emitter.removeAllListeners();
-  });
+  var promises = Object.keys(this.subscriptions)
+    .map(function(sub) {
+      var subscriptionsInfo = self.subscriptions[sub];
+      subscriptionsInfo.emitter.removeAllListeners();
+
+      var promise = subscriptionsInfo.subscribe;
+
+      if (promise.isCancellable()) {
+        promise.cancel();
+        return null;
+      } else {
+        return promise.then(function(subscription) {
+          return subscription.unsubscribe(); // TODO: catch
+        });
+      }
+    });
+
+    return Promise.all(promises)
+      .bind(this)
+      .catch(function() {
+        // Ignore unsubscribe errors, we plan to disconnect anyway
+      })
+      .then(function() {
+        return this.client.disconnect();
+      });
+
+
 };
 
 module.exports = FayeClient;

--- a/package.json
+++ b/package.json
@@ -20,15 +20,16 @@
   },
   "homepage": "https://github.com/gitterHQ/node-gitter",
   "dependencies": {
-    "debug": "^0.8.1",
+    "bluebird": "^3.1.1",
+    "debug": "^2.2.0",
     "eventemitter3": "^0.1.6",
-    "faye": "~1.0.1",
     "gitter-faye": "^1.1.0-e",
+    "halley": "^0.3.2",
     "q": "~1.0.1",
     "qs": "~1.2.1"
   },
   "devDependencies": {
-    "mocha": "~1.18.2",
-    "retire": "latest"
+    "mocha": "^2.3.4",
+    "retire": "^1.1.2"
   }
 }


### PR DESCRIPTION
[Halley](https://github.com/gitterHQ/halley) is the new Bayeux client that we're slowly switching over too on Gitter. Like Faye, it talks standard Bayeux protocol, but has been tested under the type of adverse network conditions we see a lot of on the internet.

This branch switches from Faye to Halley. Additionally, it disconnects the client on `disconnect`